### PR TITLE
Fix joint state publisher plugin references

### DIFF
--- a/ezgripper_driver/urdf/ezgripper_dual_gen2_articulated.urdf.xacro
+++ b/ezgripper_driver/urdf/ezgripper_dual_gen2_articulated.urdf.xacro
@@ -152,7 +152,7 @@
 <xacro:macro name="gazebo_knuckle_jsp" params="prefix">
    <gazebo>
      <plugin name="joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
-       <jointName>${prefix}_ezgripper_knuckle_1,${prefix}_ezgripper_knuckle_2</jointName>
+       <jointName>${prefix}_ezgripper_knuckle_L1_L2_1,${prefix}_ezgripper_knuckle_L1_L2_2</jointName>
      </plugin>
    </gazebo>
 </xacro:macro>

--- a/ezgripper_driver/urdf/ezgripper_dual_gen2_articulated.urdf.xacro
+++ b/ezgripper_driver/urdf/ezgripper_dual_gen2_articulated.urdf.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot name="ezgripper" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="ezgripper" xmlns:xacro="http://ros.org/wiki/xacro">
 
-<!--macro name="ezgripper" params="*origin"-->
+<!--xacro:macro name="ezgripper" params="*origin"-->
 
 
 
-<macro name="ezgripper_dual" params="prefix parent_link *origin">
- 
+<xacro:macro name="ezgripper_dual" params="prefix parent_link *origin">
+
 
     <!-- links -->
 
@@ -54,10 +54,10 @@
 
     <gazebo_knuckle_jsp prefix="${prefix}" />
 
-</macro>
+</xacro:macro>
 
 
-<macro name="ezgripper_finger_L1" params="prefix postfix reflect">
+<xacro:macro name="ezgripper_finger_L1" params="prefix postfix reflect">
     <link name="${prefix}_ezgripper_finger_L1_${postfix}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -76,10 +76,10 @@
         <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
       </inertial>
     </link>
-</macro>
- 
+</xacro:macro>
 
-<macro name="ezgripper_finger_L2" params="prefix postfix reflect">
+
+<xacro:macro name="ezgripper_finger_L2" params="prefix postfix reflect">
     <link name="${prefix}_ezgripper_finger_L2_${postfix}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -98,8 +98,8 @@
         <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
       </inertial>
     </link>
-</macro>
- 
+</xacro:macro>
+
 
 
 
@@ -107,7 +107,7 @@
 
 
 
-<macro name="ezgripper_knuckle_palm_L1" params="prefix postfix reflectY reflectZ reflectR mimic_test">
+<xacro:macro name="ezgripper_knuckle_palm_L1" params="prefix postfix reflectY reflectZ reflectR mimic_test">
     <joint name="${prefix}_ezgripper_knuckle_palm_L1_${postfix}" type="revolute">
       <parent link="${prefix}_ezgripper_palm_link"/>
       <child link="${prefix}_ezgripper_finger_L1_${postfix}"/>
@@ -118,9 +118,9 @@
            <mimic joint="${prefix}_ezgripper_knuckle_palm_L1_1"/>
       </xacro:if>
     </joint>
-</macro>
+</xacro:macro>
 
-<macro name="ezgripper_knuckle_L1_L2" params="prefix postfix reflectY reflectZ reflectR mimic_test">
+<xacro:macro name="ezgripper_knuckle_L1_L2" params="prefix postfix reflectY reflectZ reflectR mimic_test">
     <joint name="${prefix}_ezgripper_knuckle_L1_L2_${postfix}" type="revolute">
       <parent link="${prefix}_ezgripper_finger_L1_${postfix}"/>
       <child link="${prefix}_ezgripper_finger_L2_${postfix}"/>
@@ -132,11 +132,11 @@
            <mimic joint="${prefix}_ezgripper_knuckle_L1_L2_1"/>
       </xacro:if>
     </joint>
-</macro>
+</xacro:macro>
 
     <!-- transmissions for Gazebo -->
 
-<macro name="ezgripper_knuckle_trans" params="prefix postfix">
+<xacro:macro name="ezgripper_knuckle_trans" params="prefix postfix">
    <transmission name="${prefix}_ezgripper_trans_${postfix}">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_ezgripper_knuckle_${postfix}">
@@ -147,15 +147,15 @@
          <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
       </actuator>
    </transmission>
-</macro>
+</xacro:macro>
 
-<macro name="gazebo_knuckle_jsp" params="prefix">
+<xacro:macro name="gazebo_knuckle_jsp" params="prefix">
    <gazebo>
      <plugin name="joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
        <jointName>${prefix}_ezgripper_knuckle_1,${prefix}_ezgripper_knuckle_2</jointName>
      </plugin>
    </gazebo>
-</macro>
+</xacro:macro>
 
 
 <gazebo>

--- a/ezgripper_driver/urdf/ezgripper_dual_gen2_articulated.urdf.xacro
+++ b/ezgripper_driver/urdf/ezgripper_dual_gen2_articulated.urdf.xacro
@@ -50,8 +50,7 @@
     <ezgripper_knuckle_L1_L2 prefix="${prefix}" postfix="1" reflectY="1" reflectZ="1" reflectR="-1" mimic_test="false"/>
     <ezgripper_knuckle_L1_L2 prefix="${prefix}" postfix="2" reflectY="-1" reflectZ="1" reflectR="1" mimic_test="true"/>
 
-    <ezgripper_knuckle_trans prefix="${prefix}" postfix="1"/>
-    <ezgripper_knuckle_trans prefix="${prefix}" postfix="2"/>
+    <ezgripper_knuckle_trans prefix="${prefix}" postfix="L1_L2_1"/>
 
     <gazebo_knuckle_jsp prefix="${prefix}" />
 
@@ -141,11 +140,11 @@
    <transmission name="${prefix}_ezgripper_trans_${postfix}">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_ezgripper_knuckle_${postfix}">
-         <hardwareInterface>PositionJointInterface</hardwareInterface>
+         <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
       </joint>
       <actuator name="${prefix}_ezgripper_motor${postfix}">
          <mechanicalReduction>1</mechanicalReduction>
-         <hardwareInterface>PositionJointInterface</hardwareInterface>
+         <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
       </actuator>
    </transmission>
 </macro>
@@ -153,7 +152,7 @@
 <macro name="gazebo_knuckle_jsp" params="prefix">
    <gazebo>
      <plugin name="joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
-       <jointName>${prefix}_ezgripper_knuckle_1,${prefix}_ezgripper_knuckle_2  </jointName>
+       <jointName>${prefix}_ezgripper_knuckle_1,${prefix}_ezgripper_knuckle_2</jointName>
      </plugin>
    </gazebo>
 </macro>


### PR DESCRIPTION
Hi,

Whenever I tried to start gazebo from a launch file using the dual gen2 gripper gazebo would segfault. I posted about this issue in the gazebo repository here https://bitbucket.org/osrf/gazebo/issues/2330/gazebo-segfaults-on-launch. 

Anyway it appears it is because the joint state publisher plugin definition refers to non-existent joints. Here is an attempt to fix the issue. I tested this on gazebo 7.5.0. with the gripper connected to a ur-5 and it appears to work.

Let me know what you think.

Cheers!