### PR TITLE
fix xacro warnings

### DIFF
--- a/ezgripper_driver/urdf/ezgripper_dual_articulated.urdf.xacro
+++ b/ezgripper_driver/urdf/ezgripper_dual_articulated.urdf.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot name="ezgripper" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="ezgripper" xmlns:xacro="http://ros.org/wiki/xacro">
 
 <!--macro name="ezgripper" params="*origin"-->
 
 
 
-<macro name="ezgripper_dual" params="prefix parent_link *origin">
- 
+<xacro:macro name="ezgripper_dual" params="prefix parent_link *origin">
+
 
     <!-- links -->
 
@@ -54,10 +54,10 @@
 
     <gazebo_knuckle_jsp prefix="${prefix}" />
 
-</macro>
+</xacro:macro>
 
 
-<macro name="ezgripper_finger_L1" params="prefix postfix reflect">
+<xacro:macro name="ezgripper_finger_L1" params="prefix postfix reflect">
     <link name="${prefix}_ezgripper_finger_L1_${postfix}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -76,10 +76,10 @@
         <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
       </inertial>
     </link>
-</macro>
- 
+</xacro:macro>
 
-<macro name="ezgripper_finger_L2" params="prefix postfix reflect">
+
+<xacro:macro name="ezgripper_finger_L2" params="prefix postfix reflect">
     <link name="${prefix}_ezgripper_finger_L2_${postfix}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -98,8 +98,8 @@
         <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
       </inertial>
     </link>
-</macro>
- 
+</xacro:macro>
+
 
 
 
@@ -107,7 +107,7 @@
 
 
 
-<macro name="ezgripper_knuckle_palm_L1" params="prefix postfix reflectY reflectZ reflectR mimic_test">
+<xacro:macro name="ezgripper_knuckle_palm_L1" params="prefix postfix reflectY reflectZ reflectR mimic_test">
     <joint name="${prefix}_ezgripper_knuckle_palm_L1_${postfix}" type="revolute">
       <parent link="${prefix}_ezgripper_palm_link"/>
       <child link="${prefix}_ezgripper_finger_L1_${postfix}"/>
@@ -118,9 +118,9 @@
            <mimic joint="${prefix}_ezgripper_knuckle_palm_L1_1"/>
       </xacro:if>
     </joint>
-</macro>
+</xacro:macro>
 
-<macro name="ezgripper_knuckle_L1_L2" params="prefix postfix reflectY reflectZ reflectR mimic_test">
+<xacro:macro name="ezgripper_knuckle_L1_L2" params="prefix postfix reflectY reflectZ reflectR mimic_test">
     <joint name="${prefix}_ezgripper_knuckle_L1_L2_${postfix}" type="revolute">
       <parent link="${prefix}_ezgripper_finger_L1_${postfix}"/>
       <child link="${prefix}_ezgripper_finger_L2_${postfix}"/>
@@ -131,11 +131,11 @@
            <mimic joint="${prefix}_ezgripper_knuckle_L1_L2_1"/>
       </xacro:if>
     </joint>
-</macro>
+</xacro:macro>
 
     <!-- transmissions for Gazebo -->
 
-<macro name="ezgripper_knuckle_trans" params="prefix postfix">
+<xacro:macro name="ezgripper_knuckle_trans" params="prefix postfix">
    <transmission name="${prefix}_ezgripper_trans_${postfix}">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_ezgripper_knuckle_${postfix}">
@@ -146,15 +146,15 @@
          <hardwareInterface>PositionJointInterface</hardwareInterface>
       </actuator>
    </transmission>
-</macro>
+</xacro:macro>
 
-<macro name="gazebo_knuckle_jsp" params="prefix">
+<xacro:macro name="gazebo_knuckle_jsp" params="prefix">
    <gazebo>
      <plugin name="joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
        <jointName>${prefix}_ezgripper_knuckle_1,${prefix}_ezgripper_knuckle_2  </jointName>
      </plugin>
    </gazebo>
-</macro>
+</xacro:macro>
 
 
 <gazebo>
@@ -162,5 +162,3 @@
    </plugin>
 </gazebo>
 </robot>
-
-

--- a/ezgripper_driver/urdf/ezgripper_dual_gen2.urdf.xacro
+++ b/ezgripper_driver/urdf/ezgripper_dual_gen2.urdf.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot name="ezgripper" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="ezgripper" xmlns:xacro="http://ros.org/wiki/xacro">
 
 <!--macro name="ezgripper" params="*origin"-->
 
 
 
-<macro name="ezgripper_dual_gen2" params="prefix parent_link *origin">
- 
+<xacro:macro name="ezgripper_dual_gen2" params="prefix parent_link *origin">
+
 
     <!-- links -->
 
@@ -48,10 +48,10 @@
 
     <gazebo_knuckle_jsp prefix="${prefix}" />
 
-</macro>
+</xacro:macro>
 
 
-<macro name="ezgripper_finger" params="prefix postfix reflect">
+<xacro:macro name="ezgripper_finger" params="prefix postfix reflect">
     <link name="${prefix}_ezgripper_finger_${postfix}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -70,14 +70,14 @@
         <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy="0.01" iyz="0.0" izz="0.01"/>
       </inertial>
     </link>
-</macro>
- 
+</xacro:macro>
+
 
     <!-- joints -->
 
 
 
-<macro name="ezgripper_knuckle" params="prefix postfix reflectY reflectZ reflectR mimic_test">
+<xacro:macro name="ezgripper_knuckle" params="prefix postfix reflectY reflectZ reflectR mimic_test">
     <joint name="${prefix}_ezgripper_knuckle_${postfix}" type="revolute">
       <parent link="${prefix}_ezgripper_palm_link"/>
       <child link="${prefix}_ezgripper_finger_${postfix}"/>
@@ -88,10 +88,10 @@
            <mimic joint="ezgripper_knuckle_1"/>
       </xacro:if>
     </joint>
-</macro>
+</xacro:macro>
     <!-- transmissions for Gazebo -->
 
-<macro name="ezgripper_knuckle_trans" params="prefix postfix">
+<xacro:macro name="ezgripper_knuckle_trans" params="prefix postfix">
    <transmission name="${prefix}_ezgripper_trans_${postfix}">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_ezgripper_knuckle_${postfix}">
@@ -102,15 +102,15 @@
          <hardwareInterface>PositionJointInterface</hardwareInterface>
       </actuator>
    </transmission>
-</macro>
+</xacro:macro>
 
-<macro name="gazeobo_knuckle_jsp" params="prefix">
+<xacro:macro name="gazeobo_knuckle_jsp" params="prefix">
    <gazebo>
      <plugin name="joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
        <jointName>${prefix}_ezgripper_knuckle_1,${prefix}_ezgripper_knuckle_2  </jointName>
      </plugin>
    </gazebo>
-</macro>
+</xacro:macro>
 
 
 <gazebo>
@@ -118,5 +118,3 @@
    </plugin>
 </gazebo>
 </robot>
-
-

--- a/ezgripper_driver/urdf/ezgripper_dual_gen2_standalone.urdf.xacro
+++ b/ezgripper_driver/urdf/ezgripper_dual_gen2_standalone.urdf.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot name="ezgripper_stand_alone" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="ezgripper_stand_alone" xmlns:xacro="http://ros.org/wiki/xacro">
 
 
-<property name="ezgripper_offset_x" value="0.0"/>
-<property name="ezgripper_offset_y" value="0.0"/>
-<property name="ezgripper_offset_z" value="0.0"/>
+<xacro:property name="ezgripper_offset_x" value="0.0"/>
+<xacro:property name="ezgripper_offset_y" value="0.0"/>
+<xacro:property name="ezgripper_offset_z" value="0.0"/>
 
 
 <xacro:include filename="$(find ezgripper_driver)/urdf/ezgripper_dual_gen2_articulated.urdf.xacro"/>

--- a/ezgripper_driver/urdf/ezgripper_dual_standalone.urdf.xacro
+++ b/ezgripper_driver/urdf/ezgripper_dual_standalone.urdf.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot name="ezgripper_stand_alone" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="ezgripper_stand_alone" xmlns:xacro="http://ros.org/wiki/xacro">
 
 
-<property name="ezgripper_offset_x" value="0.049"/>
-<property name="ezgripper_offset_y" value="0.0"/>
-<property name="ezgripper_offset_z" value="0.21"/>
+<xacro:property name="ezgripper_offset_x" value="0.049"/>
+<xacro:property name="ezgripper_offset_y" value="0.0"/>
+<xacro:property name="ezgripper_offset_z" value="0.21"/>
 
 
 <xacro:include filename="$(find ezgripper_driver)/urdf/ezgripper_dual.urdf.xacro"/>

--- a/ezgripper_driver/urdf/ezgripper_quad.urdf.xacro
+++ b/ezgripper_driver/urdf/ezgripper_quad.urdf.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot name="ezgripper" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="ezgripper" xmlns:xacro="http://ros.org/wiki/xacro">
 
-<macro name="ezgripper_quad" params="prefix parent_link *origin">
- 
+<xacro:macro name="ezgripper_quad" params="prefix parent_link *origin">
+
     <!-- links -->
 
     <link name="${prefix}_ezgripper_palm_link">
@@ -49,14 +49,14 @@
     <ezgripper_knuckle_trans prefix="${prefix}" postfix="2"/>
     <ezgripper_knuckle_trans prefix="${prefix}" postfix="3"/>
     <ezgripper_knuckle_trans prefix="${prefix}" postfix="4"/>
- 
+
     <gazebo_knuckle_jsp prefix="${prefix}" />
 
 
-</macro>
+</xacro:macro>
 
 
-<macro name="ezgripper_finger" params="prefix postfix reflect">
+<xacro:macro name="ezgripper_finger" params="prefix postfix reflect">
     <link name="${prefix}_ezgripper_finger_${postfix}">
       <visual>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -75,14 +75,14 @@
         <inertia ixx="0.01" ixy="0.0" ixz="0.0" iyy=".01" iyz="0.0" izz="0.01"/>
       </inertial>
     </link>
-</macro>
- 
+</xacro:macro>
+
 
     <!-- joints -->
 
 
 
-<macro name="ezgripper_knuckle" params="prefix postfix reflectY reflectZ reflectR mimic_test">
+<xacro:macro name="ezgripper_knuckle" params="prefix postfix reflectY reflectZ reflectR mimic_test">
     <joint name="${prefix}_ezgripper_knuckle_${postfix}" type="revolute">
       <parent link="${prefix}_ezgripper_palm_link"/>
       <child link="${prefix}_ezgripper_finger_${postfix}"/>
@@ -93,11 +93,11 @@
            <mimic joint="${prefix}_ezgripper_knuckle_1"/>
       </xacro:if>
     </joint>
-</macro>
+</xacro:macro>
 
     <!-- transmissions for Gazebo -->
 
-<macro name="ezgripper_knuckle_trans" params="prefix postfix">
+<xacro:macro name="ezgripper_knuckle_trans" params="prefix postfix">
    <transmission name="${prefix}_ezgripper_trans_${postfix}">
       <type>transmission_interface/SimpleTransmission</type>
       <joint name="${prefix}_ezgripper_knuckle_${postfix}">
@@ -108,21 +108,19 @@
          <hardwareInterface>PositionJointInterface</hardwareInterface>
       </actuator>
    </transmission>
-</macro>
+</xacro:macro>
 
-<macro name="gazebo_knuckle_jsp" params="prefix">
+<xacro:macro name="gazebo_knuckle_jsp" params="prefix">
     <gazebo>
       <plugin name="joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
         <jointName>${prefix}_ezgripper_knuckle_1,${prefix}_ezgripper_knuckle_2,${prefix}_ezgripper_knuckle_3,${prefix}_ezgripper_knuckle_4  </jointName>
       </plugin>
     </gazebo>
-</macro>
+</xacro:macro>
 
 <gazebo>
    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-       
+
    </plugin>
 </gazebo>
 </robot>
-
-

--- a/ezgripper_driver/urdf/ezgripper_quad_standalone.urdf.xacro
+++ b/ezgripper_driver/urdf/ezgripper_quad_standalone.urdf.xacro
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<robot name="ezgripper_stand_alone" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="ezgripper_stand_alone" xmlns:xacro="http://ros.org/wiki/xacro">
 
 
-<property name="ezgripper_offset_x" value="0.049"/>
-<property name="ezgripper_offset_y" value="0.0"/>
-<property name="ezgripper_offset_z" value="0.21"/>
+<xacro:property name="ezgripper_offset_x" value="0.049"/>
+<xacro:property name="ezgripper_offset_y" value="0.0"/>
+<xacro:property name="ezgripper_offset_z" value="0.21"/>
 
 
 <xacro:include filename="$(find ezgripper_driver)/urdf/ezgripper_quad.urdf.xacro"/>


### PR DESCRIPTION
`xacro` spit out some warning when exporting a URDF file. This patch fixes the warnings.